### PR TITLE
fix for allora v0.12.0 (GLIBC_2.38 required)

### DIFF
--- a/cosmovisor/Dockerfile.binary
+++ b/cosmovisor/Dockerfile.binary
@@ -1,14 +1,14 @@
 # Get dasel
 FROM ghcr.io/tomwright/dasel:2-alpine AS dasel
 
-FROM debian:bookworm-slim
+FROM ubuntu:24.04
 
 ARG USER=cosmos
 ARG UID=10001
 ARG COSMOVISOR_VERSION=v1.5.0
 ARG PRIV_VALIDATOR_PATH=/cosmos/priv_validator
 
-RUN apt-get update && apt-get install -y ca-certificates tzdata bash curl wget lz4 jq tar
+RUN apt-get update && apt-get install -y adduser ca-certificates tzdata bash curl wget lz4 jq tar
 
 # Define mounted volume
 VOLUME /cosmos


### PR DESCRIPTION
Allora v0.12.0 requires GLIBC_2.38
switched underlying image from debian:bookworm-slim to ubuntu:24.04
